### PR TITLE
replace loading animation with css spinning disc

### DIFF
--- a/app/assets/stylesheets/app/loading-animation.scss
+++ b/app/assets/stylesheets/app/loading-animation.scss
@@ -1,0 +1,47 @@
+.content-loading {
+  background-color: #405A3E;
+}
+
+.loading-animation-container {
+	width: 100%;
+	height: 100%;
+	text-align: center;
+}
+
+.loading-animation-speeding-disc {
+  width: 100px;
+  height: 100px;
+  border: 5px solid rgba(255,255,255, 0.2);
+  background-color: rgba(255, 255, 255, 0.6);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin: -80px 0 0 -50px;
+  border-radius: 50%;
+  border-right-color: rgba(255,255,255,1);
+  animation: loading-animation-spin 150ms infinite linear;
+  -o-animation: loading-animation-spin 150ms infinite linear;
+  -ms-animation: loading-animation-spin 150ms infinite linear;
+  -webkit-animation: loading-animation-spin 150ms infinite linear;
+  -moz-animation: loading-animation-spin 150ms infinite linear;
+}
+
+@keyframes loading-animation-spin {
+	100%{ transform: rotate(360deg); transform: rotate(360deg); }
+}
+
+@-o-keyframes loading-animation-spin {
+	100%{ -o-transform: rotate(360deg); transform: rotate(360deg); }
+}
+
+@-ms-keyframes loading-animation-spin {
+	100%{ -ms-transform: rotate(360deg); transform: rotate(360deg); }
+}
+
+@-webkit-keyframes loading-animation-spin {
+	100%{ -webkit-transform: rotate(360deg); transform: rotate(360deg); }
+}
+
+@-moz-keyframes loading-animation-spin {
+	100%{ -moz-transform: rotate(360deg); transform: rotate(360deg); }
+}

--- a/app/assets/stylesheets/app/styles.scss
+++ b/app/assets/stylesheets/app/styles.scss
@@ -1,5 +1,6 @@
 @import 'ratchet/variables';
 @import 'mixins';
+@import 'loading-animation';
 
 .hide {
   display: none;

--- a/app/views/app/_main_screen.html.erb
+++ b/app/views/app/_main_screen.html.erb
@@ -42,7 +42,9 @@
 </div>
 
 <div class="content content-loading center">
-  <%= image_tag "balls.gif", class: 'loading-gif' %>
+  <div class="loading-animation-container">
+    <div class="loading-animation-speeding-disc"></div>
+  </div>
 </div>
 
 <div id="map-canvas" style="position: absolute; width: 100%; height: 100%;"></div>


### PR DESCRIPTION
- green background
- whitish disc spinning super fast
  (Can't produce a .gif to show you with the framerate I want with the tools I've got here. Suggestions?)

To see if for longer than the half-second it's going to be shown, either throttle the simulated connection or add `display:none;` to the style of the canvas element over top.

Since the `.content-loading` is always in the back of the canvas, it's possible the spinning elements is being drawn by the mobile browser and cause lag. We could delete that node from the DOM once the canvas is up.
