### PR TITLE
fix multiple flash

### DIFF
--- a/app/assets/javascripts/admin/lib/flash.coffee
+++ b/app/assets/javascripts/admin/lib/flash.coffee
@@ -42,5 +42,9 @@ Admin.Flash = Flash =
   hide: ->
     $node = $('#flash')
     $node.find('b').text('')
-    @_animationSpeed($node, 3)
+    @_animationSpeed($node, 1)
     $node.addClass('animated slideOutDown')
+
+    delay 500, ->
+      $node.addClass('hide')
+      $node.removeClass('animated bounceInUp slideOutDown')


### PR DESCRIPTION
fixes #249

The issue was that the animation classes never reset if a flash was triggered multiple times on one page. After hiding the flash I now reset the classes.

I opted to use a delay of my own rather than `$('.modal-content').addClass('animated pulse').one 'webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', ->` this pattern from brochure since the event seemed to fire a fair bit after the animation was visually done (it was also firing again for adding the classes back since its unique according to the one). 

You still can't send flash messages super fast or else some might get lost but this isn't a valid use case
