### PR TITLE
push url params from the filter bar

### DIFF
--- a/app/assets/javascripts/admin/mixins/filter_bar.jsx
+++ b/app/assets/javascripts/admin/mixins/filter_bar.jsx
@@ -1,5 +1,7 @@
 var _ = require('underscore'),
     squish = require('object-squish'),
+    queryString = require('query-string'),
+    setQuery = require('set-query-string'),
     Input = require('react-bootstrap').Input,
     Dropdown = require('react-bootstrap').Dropdown,
     MenuItem = require('react-bootstrap').MenuItem;
@@ -7,7 +9,7 @@ var _ = require('underscore'),
 var FilterBar = {
   getDefaultProps() {
     return {
-      "query": { "search" : ""}
+      "query": queryString.parse(location.search)
     }
   },
 
@@ -20,8 +22,19 @@ var FilterBar = {
     this.props.changeFilter(this.props.query);
   },
 
+  componentWillReceiveProps() {
+    setQuery(this.props.query, {clear: true});
+  },
+
   searchChange(event) {
-    this.props.query['search'] = event.target.value;
+    var value = event.target.value;
+
+    if(value == '') {
+      delete this.props.query['search']
+    } else {
+      this.props.query['search'] = value;
+    }
+
     this.props.changeFilter(this.props.query);
   },
 
@@ -44,9 +57,12 @@ var FilterBar = {
   },
 
   _renderSearchBar() {
+    var searchValue = this.props.query.search;
+
     return (
       <div className="filter-container" style={{paddingBottom: 10}}>
         <Input type="text"
+               value={searchValue}
                name="search"
                placeholder="Search..."
                className="form-control"
@@ -56,6 +72,7 @@ var FilterBar = {
   },
 
   _renderFilterSearchBar() {
+    var searchValue = this.props.query.search;
     var filterDropdown = (
       <div className="input-group-btn">
         <Dropdown id="filter-dropdown">
@@ -86,6 +103,7 @@ var FilterBar = {
     return (
       <div className="filter-container" style={{paddingBottom: 10}}>
         <Input type="text"
+               value={searchValue}
                name="search"
                placeholder="Search..."
                className="form-control"

--- a/app/assets/javascripts/admin/mixins/filter_function.js
+++ b/app/assets/javascripts/admin/mixins/filter_function.js
@@ -24,12 +24,13 @@ var FilterFunction = {
 
       // search
       var flat = squish(item);
-      var search = filter.search.trim();
+      var search = filter.search;
       if(search) {
+        search = search.trim().toLowerCase();
         for (var key in flat) {
           if (this._keyNotSearchable(key)) continue;
 
-          if (String(flat[key]).toLowerCase().indexOf(search.toLowerCase()) >= 0) {
+          if (String(flat[key]).toLowerCase().indexOf(search) >= 0) {
             return true;
           };
         };

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "flux": "^2.1.1",
     "griddle-react": "^0.3.1",
     "object-squish": "^1.0.0",
+    "query-string": "^3.0.0",
     "react": "^0.14.3",
     "react-bootstrap": "^0.28.2",
     "react-dom": "^0.14.0",
+    "set-query-string": "^2.1.0",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
closes #253
- pushes the query to the url params
- loads the url param as the initial query
- uses replaceState so that pressing back will navigate rather than remove filters. If you have filters and navigate away and press back to return you filters will be as you left them
- I now delete the search key if it is empty string and made the filter function aware of this
