### PR TITLE
schedule editor fixes

### DIFF
--- a/app/controllers/admin/schedule_controller.rb
+++ b/app/controllers/admin/schedule_controller.rb
@@ -1,9 +1,7 @@
 class Admin::ScheduleController < AdminController
 
   def index
-    @games = @tournament.games.includes(:division)
-    @fields = @tournament.fields.sort_by{|f| f.name.gsub(/\D/, '').to_i }
-    @times = time_slots
+    load_index_data
   end
 
   def update
@@ -14,12 +12,19 @@ class Admin::ScheduleController < AdminController
       end
     end
 
-    head :ok
+    load_index_data
+    render :index
   rescue => error
     render json: {game_id: error.record.id, error: error.message}, status: :unprocessable_entity
   end
 
   private
+
+  def load_index_data
+    @games = @tournament.games.includes(:division)
+    @fields = @tournament.fields.sort_by{|f| f.name.gsub(/\D/, '').to_i }
+    @times = time_slots
+  end
 
   def time_slots
     times = @games.pluck(:start_time).uniq
@@ -42,5 +47,4 @@ class Admin::ScheduleController < AdminController
     @games_params[:games] ||= {}
     @games_params[:games].values
   end
-
 end

--- a/app/views/admin/schedule/_editor.html.erb
+++ b/app/views/admin/schedule/_editor.html.erb
@@ -6,7 +6,7 @@
   context='scheduleEditor'>
 
   <%= form_tag admin_schedule_path, "bind-event-submit" => "saveSchedule(this)" do %>
-    <div class="box box-solid" style="overflow-x: scroll;">
+    <div id="ScheduleEditor" class="box box-solid" style="overflow-x: scroll;">
 
       <div class="box-header">
         <% @games.group_by{ |g| g.division }.each do |division, games| %>
@@ -16,7 +16,9 @@
             </h3>
             <% games.each_with_index do |game, idx| %>
               <% if game.unassigned? %>
-                <div class="game draggable" style="<%= color_for_game(game) %>" data-game-id="<%= game.id %>">
+                <div class="game draggable"
+                     style="<%= color_for_game(game) %>"
+                     data-game-id="<%= game.id %>">
                   <%= game_draggable_text(game) %>
                 </div>
               <% end %>
@@ -42,14 +44,22 @@
                 <tr>
                   <td class="td-input time">
                     <div class="td-input">
-                      <input type="text" class="td-input datetimepicker form-control" value="<%= time.to_formatted_s(:datetimepicker) %>" bind-event-blur="timeUpdated(event)">
+                      <input type="text"
+                             class="td-input datetimepicker form-control"
+                             value="<%= time.to_formatted_s(:datetimepicker) %>"
+                             bind-event-blur="timeUpdated(event)">
                     </div>
                   </td>
                   <% @fields.each do |field| %>
                     <% game = @games.detect{ |g| g.field_id == field.id && g.start_time == time } %>
                     <td class="<%= 'occupied' if game %> dropzone" data-field-id="<%= field.id %>">
                       <% if game %>
-                        <div class="game draggable" style="<%= color_for_game(game) %>" data-game-id="<%= game.id %>" data-field-id="<%= field.id %>" data-start-time="'<%= time %>'" data-row-idx="<%= index %>">
+                        <div class="game draggable"
+                             style="<%= color_for_game(game) %>"
+                             data-game-id="<%= game.id %>"
+                             data-field-id="<%= field.id %>"
+                             data-start-time="'<%= time %>'"
+                             data-row-idx="<%= index %>">
                           <%= game_draggable_text(game) %>
                         </div>
                       <% end %>

--- a/test/controllers/admin/schedule_controller_test.rb
+++ b/test/controllers/admin/schedule_controller_test.rb
@@ -6,6 +6,10 @@ class Admin::ScheduleControllerTest < ActionController::TestCase
     @tournament = tournaments(:noborders)
     set_tournament(@tournament)
     sign_in users(:kevin)
+
+    @game = games(:swift_goose)
+    @field = fields(:upi2)
+    @start_time = '2016-03-10 19:13:00 -0500'
   end
 
   test "should get index" do
@@ -30,4 +34,28 @@ class Admin::ScheduleControllerTest < ActionController::TestCase
     end
   end
 
+  test "update schedule" do
+    params = {
+      games: {
+        "0" => {id: @game.id, field_id: @field.id, start_time: @start_time}
+      }
+    }
+
+    put :update, params
+    assert_response :ok
+    assert_template :index
+  end
+
+  test "update schedule 422" do
+    params = {
+      games: {
+        "0" => {id: @game.id, field_id: 'wat', start_time: @start_time}
+      }
+    }
+
+    put :update, params
+
+    assert_response :unprocessable_entity
+    assert_equal "Validation failed: Field can't be blank", response_json['error']
+  end
 end


### PR DESCRIPTION
closes #113
## Fixes:
- Replace html on success - this makes it simpler since this page doesn't keep acquiring state forever. It also lines things up nicely again
- Added a catch all error message for 500s (before I think it would fail or show a blank error)
- Keep the scroll of the editor div after save. This will be more important when I fix #374
- Remove the error class when the game is dragged.
- added update tests
