### PR TITLE
replace score edit popover with a modal

### DIFF
--- a/app/assets/stylesheets/admin/games.scss
+++ b/app/assets/stylesheets/admin/games.scss
@@ -1,3 +1,0 @@
-input.score-input {
-  max-width: 60px;
-}


### PR DESCRIPTION
closes #362

Added a nicer icon to indicate editablness of blank scores:
![image](https://cloud.githubusercontent.com/assets/1965489/14070637/a74ea83c-f476-11e5-9ea1-5bb40bf6a2b5.png)

Modal is better than popover (and simpler code):
![image](https://cloud.githubusercontent.com/assets/1965489/14070641/b7572c5e-f476-11e5-8171-dc5cecda64e0.png)
