### PR TITLE
map onboarding

### DIFF
--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -5,7 +5,7 @@ class Admin::FieldsController < AdminController
   TAB_KEY = 'fieldsTab'
 
   before_action :load_field, only: [:show, :update, :destroy]
-  before_action :load_fields, only: [:index, :new, :show]
+  before_action :load_fields, only: [:index, :new, :create, :show, :update]
   before_action :check_delete_safety, only: [:destroy]
 
   def index

--- a/app/controllers/admin/map_controller.rb
+++ b/app/controllers/admin/map_controller.rb
@@ -15,8 +15,12 @@ class Admin::MapController < AdminController
   private
 
   def tournament_params
-    params.require(:tournament).permit(
+    tournament_params = params.require(:tournament).permit(
       map_attributes: [:lat, :long, :zoom]
     )
+
+    # hack is this a rails bug?
+    tournament_params[:map_attributes][:created_at] = @map.created_at
+    tournament_params
   end
 end

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -1,4 +1,8 @@
 class Map < ActiveRecord::Base
   belongs_to :tournament
   validates_presence_of :tournament, :lat, :long, :zoom
+
+  def edited?
+    updated_at > created_at
+  end
 end

--- a/app/views/admin/_sidebar.html.erb
+++ b/app/views/admin/_sidebar.html.erb
@@ -25,6 +25,7 @@
         <%= sidebar_link "fa fa-users", "Teams", admin_teams_path %>
         <%= sidebar_link "fa fa-sitemap", "Divisions", admin_divisions_path, badge: divisions_badge(@tournament) %>
         <%= sidebar_link "fa fa-map-signs", "Fields", admin_fields_path %>
+        <%= sidebar_link "fa fa-map", "Map", admin_map_path, 'data-no-turbolink' => true %>
         <%= sidebar_link "fa fa-calendar", "Schedule", admin_schedule_path %>
         <%= sidebar_link "fa fa-list", "Games", admin_games_path, badge: games_badge(@tournament) %>
 
@@ -36,7 +37,7 @@
           </a>
           <ul class="treeview-menu">
             <%= sidebar_link nil, "Tournament", admin_settings_path %>
-            <%= sidebar_link nil, "Map", admin_map_path, 'data-no-turbolink' => true %>
+            <%= sidebar_link nil, "Account", admin_account_path %>
           </ul>
         </li>
 

--- a/app/views/admin/fields/_form.html.erb
+++ b/app/views/admin/fields/_form.html.erb
@@ -1,21 +1,48 @@
 <div class="row">
   <div class="col-md-6">
     <%= form.ui_text_field :name %>
-    <%= form.ui_text_field :lat, readonly: true %>
-    <%= form.ui_text_field :long, readonly: true %>
-    <%= form.ui_text_area :geo_json, rows: 10, readonly: true, style: 'resize: none;' %>
+    <% if @map.edited? %>
+      <br>
+      <p>
+        The following fields are created when you draw your field.
+        They're shown in case you want to copy and paste to another map
+        program.
+      </p>
+      <%= form.ui_text_field :lat, readonly: true %>
+      <%= form.ui_text_field :long, readonly: true %>
+      <%= form.ui_text_area :geo_json, rows: 10, readonly: true, style: 'resize: none;' %>
+    <% end %>
   </div>
 
   <div class="col-md-6">
-    <div class="row" define="{fieldEditor: new Admin.FieldEditor(
-        <%= @map.zoom %>,
-        <%= @field.to_json %>,
-        <%= @fields.to_json || [] %>
-      )}">
-      <div class="col-md-12">
-        <div id="_map" style="width: 100%; height: 640px;"></div>
+    <% if @map.edited? %>
+      <% if @field.new_record? %>
+        <p>
+          Draw your field on the map.
+        </p>
+      <% else %>
+        <p>
+          Edit your field drawing.
+        </p>
+      <% end %>
+      <p>
+        If the map isn't quite where you want it positioned you can edit it <%= link_to 'here', admin_map_path %>.
+      </p>
+      <div class="row" define="{fieldEditor: new Admin.FieldEditor(
+          <%= @map.zoom %>,
+          <%= @field.to_json %>,
+          <%= @fields.to_json || [] %>
+        )}">
+        <div class="col-md-12">
+          <div id="_map" style="width: 100%; height: 640px;"></div>
+        </div>
       </div>
-    </div>
+    <% else %>
+      <div style="padding-top: 30px;">
+        <i class="fa fa-exclamation-triangle"></i>
+        Set up your <%= link_to 'Map', admin_map_path %> so you can add fields to it!
+      </div>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
- Fixes a bug with not loading all the other fields to draw for update and create
- Show a blank slate for field maps until the user has edited the field (I think I found a rails bug here since rails is updating the created_at on saves ... its related to the nested attributes)
- Added some copy explaining more about what to do on the fields page
- Made map a full sidebar citizen
- Added accounts to the settings dropdown so I can keep the dropdown. Also helps with discovering it

Couple of future notes:
- Eventually I will have facilities
- Currently a map is basically a facility and you are only allowed one. (this is an easy migration path to go forward from)
- When I add facilities don't nest fields under them on the sidebar but keep both top level nav items with a select a facility dropdown when creating a field just like team with division
  - can't really update facility though. you have to recreate the field in the other facility 
- Player app will determine which facility you are at and snap to that map 
