### PR TITLE
show bracket bis in a modal for mobile

### DIFF
--- a/app/assets/javascripts/admin/lib/small_screen.coffee
+++ b/app/assets/javascripts/admin/lib/small_screen.coffee
@@ -1,0 +1,2 @@
+@smallScreen = ->
+  $(window).width() < 767

--- a/app/assets/javascripts/admin/modules/bracket.coffee
+++ b/app/assets/javascripts/admin/modules/bracket.coffee
@@ -1,6 +1,6 @@
 class Admin.Bracket
 
-  constructor: (node, bracketName) ->
+  constructor: (node) ->
     @descTemplate = _.template(TEMPLATES.description)
     @poolsTemplate = _.template(TEMPLATES.pools)
     @noPoolsTemplate = _.template(TEMPLATES.no_pools)
@@ -8,7 +8,12 @@ class Admin.Bracket
     @$node = $(node)
     @$bracketDescNode = @$node.find('#bracketDescription')
     @$bracketPoolsNode = @$node.find('#bracketPools')
-    @$bracketGraphNode = @$node.find('#bracketGraph')
+
+    # bracket graph is in modal on small screens
+    @$bracketGraphNode = if window.smallScreen()
+      @$node.find('.modal').find('#bracketGraph')
+    else
+      @$node.find('.col-md-8').find('#bracketGraph')
 
   render: (bracketName) ->
     bracket = Admin.BracketDb.find(bracketName)

--- a/app/assets/javascripts/admin/modules/bracket_vis.coffee
+++ b/app/assets/javascripts/admin/modules/bracket_vis.coffee
@@ -44,6 +44,9 @@ class Admin.BracketVis
     data = @graphFromBracket(bracket)
     vis = new window.vis.Network(@node, data, options)
 
+    $('#bracketVisModal').on 'shown.bs.modal', (e) ->
+      vis.fit()
+
     if @debug
       vis.on "configChange", =>
         div = $('.vis-configuration-wrapper')[0]

--- a/app/assets/javascripts/admin/modules/sidebar.coffee
+++ b/app/assets/javascripts/admin/modules/sidebar.coffee
@@ -1,7 +1,7 @@
 class Sidebar
 
   toggle: ->
-    if @_smallScreen()
+    if window.smallScreen()
       klass = "sidebar-open"
       if @_open(klass) then @close(klass) else @open(klass)
     else
@@ -17,7 +17,7 @@ class Sidebar
     return if $node.length == 0
     event.preventDefault()
 
-    @close() if @_smallScreen()
+    @close() if window.smallScreen()
     Turbolinks.visit($node.attr('href'))
 
   # desktop and tablet
@@ -43,9 +43,6 @@ class Sidebar
 
   _open: (klass) ->
     $('body').hasClass(klass)
-
-  _smallScreen: ->
-    $(window).width() < 767
 
 instance = new Sidebar
 

--- a/app/assets/stylesheets/admin/bracket.scss
+++ b/app/assets/stylesheets/admin/bracket.scss
@@ -1,0 +1,15 @@
+#bracketVisModal {
+  .modal-header {
+    border: none;
+  }
+  .modal-dialog {
+    top: -5px;
+  }
+
+  .animated {
+    -webkit-animation-duration: 0.25s;
+    -moz-animation-duration: 0.25s;
+    -ms-animation-duration: 0.25s;
+    -o-animation-duration: 0.25s;
+  }
+}

--- a/app/views/admin/divisions/_bracket.html.erb
+++ b/app/views/admin/divisions/_bracket.html.erb
@@ -1,18 +1,33 @@
 <div define="{bracket: new Admin.Bracket(this)}">
-  <%= ui_box do %>
-    <div class="row">
-      <div id="bracketDescription" class="col-md-10">
+  <div class="hidden-xs">
+    <%= ui_box do %>
+      <div class="row">
+        <div id="bracketDescription" class="col-md-10">
+        </div>
+      </div>
+      <hr>
+      <div class="row">
+        <div class="col-md-4">
+          <div id="bracketPools"></div>
+        </div>
+        <div class="col-md-8 pull-right">
+          <div id="bracketGraph" style="height: 440px;"></div>
+        </div>
+      </div>
+      <div id="visConfigure"></div>
+    <% end %>
+  </div>
+
+  <div class="modal" id="bracketVisModal">
+    <div class="modal-dialog animated fadeInRight">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>
+        </div>
+        <div class="modal-body">
+          <div id="bracketGraph" style="height: 88vh;"></div>
+        </div>
       </div>
     </div>
-    <hr>
-    <div class="row">
-      <div class="col-md-4">
-        <div id="bracketPools"></div>
-      </div>
-      <div class="col-md-8 pull-right">
-        <div id="bracketGraph" style="height: 440px;"></div>
-      </div>
-    </div>
-    <div id="visConfigure"></div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/admin/divisions/_form.html.erb
+++ b/app/views/admin/divisions/_form.html.erb
@@ -13,6 +13,14 @@
     <% options = bracket_options(division) %>
     <%= form.ui_select :bracket_type, 'Bracket', options, disabled:  options.blank? %>
 
+    <div class="hidden-sm hidden-md hidden-lg">
+      <div class="form-group">
+        <button type="button" class="btn btn-block btn-info btn-lg" data-toggle="modal" data-target="#bracketVisModal">
+          View Bracket <i class="fa fa-external-link-square" aria-hidden="true"></i>
+        </button>
+      </div>
+    </div>
+
     <div class="panel panel-default subdued">
       <div class="panel-body">
         <i class="fa fa-question-circle"></i>


### PR DESCRIPTION
closes #452 by moving the bracket visualization to a modal on mobile.

Its pretty sick the way this worked out - I set up the two containers and then based off the screen size pick which one I should pick for the vis. I also needed an extra event on the modal open to reszie vis.
