### PR TITLE
add ability to unschedule games

### DIFF
--- a/app/assets/javascripts/admin/modules/schedule_dnd.coffee
+++ b/app/assets/javascripts/admin/modules/schedule_dnd.coffee
@@ -10,18 +10,40 @@ class Admin.ScheduleDnD
       gameNode = dropCell.children[0]
       gameNode.classList.remove('game-error')
 
+    @rd.event.deleted = (__, gameNode) =>
+      @_unhighlight()
+      @_gameUnassigned(gameNode)
+
+      divisionId = $(gameNode).attr('data-division-id')
+      # consciously appending a simple row on purpose
+      # this table actually has 2 rows but its edge casey
+      # enough to not need to insert at maximum space efficiency
+      $("table#division-#{divisionId} tbody").append(
+        "<tr>
+          <td class='redips-mark'>
+            #{gameNode.outerHTML}
+          </td>
+        </tr>"
+      )
+
+      @rd.init()
+
     @rd.event.dropped = (dropCell) =>
-      # game was dropped and returned to original position
+      # game was dropped and returned to original unscheduled position
       return if 'redips-mark' in dropCell.classList
 
       @_hideBanner()
-      @_unhighlightCells()
+      @_unhighlight()
       gameNode = dropCell.children
       @_gameAssigned(gameNode, dropCell)
 
     @rd.event.changed = (dropCell) =>
-      @_unhighlightCells()
-      @_highlightCells(dropCell)
+      @_unhighlight()
+
+      if 'redips-trash' in dropCell.classList
+        $('#games-card').find('.box-body').addClass('drop-hover')
+      else
+        @_highlightCells(dropCell)
 
   _gameAssigned: (game, slot) ->
     fieldId = $(slot).data('field-id')
@@ -35,6 +57,13 @@ class Admin.ScheduleDnD
     $game.attr('data-row-idx', rowIdx)
     $game.attr('data-field-id', fieldId)
     $game.attr('data-start-time', startTime)
+
+  _gameUnassigned: (game) ->
+    $game = $(game)
+    $game.attr('data-changed', true)
+    $game.removeAttr('data-row-idx')
+    $game.removeAttr('data-field-id')
+    $game.removeAttr('data-start-time')
 
   _hideBanner: ->
     $banner = $('.alert-dismissable')
@@ -51,6 +80,10 @@ class Admin.ScheduleDnD
       classes: 'dropzone-label'
       position: 'top center'
     @_drop.open()
+
+  _unhighlight: ->
+    $('.drop-hover').removeClass('drop-hover')
+    @_unhighlightCells()
 
   _unhighlightCells: ->
     $('.drop-target').removeClass('drop-target')

--- a/app/assets/javascripts/vendor/redips-drag.js
+++ b/app/assets/javascripts/vendor/redips-drag.js
@@ -1,3 +1,6 @@
+// modified by Kevin Hughes to return the object being deleted
+// in the deleted event
+
 /*
 Copyright (c) 2008-2011, www.redips.net All rights reserved.
 Code licensed under the BSD License: http://www.redips.net/license/
@@ -1197,7 +1200,7 @@ REDIPS.drag = (function () {
 						// Are you sure?
 						if (confirm(REDIPS.drag.trash.question)) {
 							// yes, do all actions needed after element is deleted
-							elementDeleted();
+							elementDeleted(obj);
 						}
 						// no, do undelete
 						else {
@@ -1215,7 +1218,7 @@ REDIPS.drag = (function () {
 				}
 				// element is deleted and do all actions needed after element is deleted
 				else {
-					elementDeleted();
+					elementDeleted(obj);
 				}
 			}
 			else if (REDIPS.drag.dropMode === 'switch') {
@@ -1416,7 +1419,7 @@ REDIPS.drag = (function () {
 	 * @private
 	 * @memberOf REDIPS.drag#
 	 */
-	elementDeleted = function () {
+	elementDeleted = function (obj) {
 		// set param needed to find last cell (for case where shift.after is 'always' or 'delete')
 		var param;
 		// if object is cloned, update climit1_X or climit2_X classname
@@ -1441,7 +1444,7 @@ REDIPS.drag = (function () {
 		}
 		// call event.deleted() method and send cloned flag
 		// inside event.deleted it's possible to know whether cloned element is directly moved to the trash
-		REDIPS.drag.event.deleted(cloned);
+		REDIPS.drag.event.deleted(cloned, obj);
 	};
 
 

--- a/app/assets/stylesheets/admin/schedule_editor.scss
+++ b/app/assets/stylesheets/admin/schedule_editor.scss
@@ -24,6 +24,9 @@ $header-height: 32px;
 }
 
 #games-card {
+  .drop-hover {
+    background-color: #f5f5f5;
+  }
   .table {
     width: auto;
   }

--- a/app/views/admin/schedule/_games.html.erb
+++ b/app/views/admin/schedule/_games.html.erb
@@ -4,11 +4,11 @@
       <tbody>
         <tr>
           <% @games.group_by{ |g| g.division }.each do |division, games| %>
-            <td class="game-col redips-mark">
+            <td class="game-col redips-mark redips-trash">
               <h3>
                 <i class="fa fa-stop" style="<%= color_for_division(division) %>"></i> <%= division.name %>
               </h3>
-              <table id="<%= division %>">
+              <table id="division-<%= division.id %>">
                 <tbody>
                   <% games.select{ |g| g.unassigned? }.each_slice(2) do |_games| %>
                     <tr>
@@ -16,7 +16,8 @@
                         <td class="redips-mark">
                           <div class="game redips-drag"
                                style="<%= color_for_game(game) %>"
-                               data-game-id="<%= game.id %>">
+                               data-game-id="<%= game.id %>"
+                               data-division-id="<%= game.division_id %>">
                             <%= game_draggable_text(game) %>
                           </div>
                         </td>

--- a/app/views/admin/schedule/_schedule_table.html.erb
+++ b/app/views/admin/schedule/_schedule_table.html.erb
@@ -29,6 +29,7 @@
                     <div class="game redips-drag"
                          style="<%= color_for_game(game) %>"
                          data-game-id="<%= game.id %>"
+                         data-division-id="<%= game.division_id %>"
                          data-field-id="<%= field.id %>"
                          data-start-time="'<%= time %>'"
                          data-row-idx="<%= index %>">


### PR DESCRIPTION
closes #478

I had to patch REDIPS to return the object being deleted (seems like a reasonable thing though). Then I unassign all schedule attributes and append it back to its division table in the `#games-card`. To do this I also added `data-division-id` params to each game draggable since I need this to figure out which division to put it back into. The division param is ignored by strong params though. Unassigning also sets `data-changed` to true so that the update call will pick it up and send it on to the server.

I on purpose only append a single row rather than figuring out if I actually need one. This is possible to do but not worth the effort. For someone to actually be affected in an annoying way they would have to delete a ton of games in one go which I think is fairly edge casey.
