### PR TITLE
adds a reset data button with confirm on the tournament page

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -13,6 +13,12 @@ class Admin::SettingsController < AdminController
     end
   end
 
+  def reset_data
+    @tournament.reset_data!
+    flash[:notice] = 'Data reset.'
+    redirect_to admin_settings_path
+  end
+
   private
 
   def tournament_params

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -27,6 +27,16 @@ class Tournament < ApplicationRecord
   validates :time_cap, presence: true, numericality: {greater_than_or_equal_to: 0}
   validates_presence_of :tournament_users, on: :update
 
+  def reset_data!
+    fields.destroy_all
+    teams.destroy_all
+    divisions.destroy_all
+    games.destroy_all
+    pool_results.destroy_all
+    places.destroy_all
+    score_reports.destroy_all
+  end
+
   def downcase_handle
     self.handle.downcase!
   end

--- a/app/views/admin/settings/_confirm_reset_modal.html.erb
+++ b/app/views/admin/settings/_confirm_reset_modal.html.erb
@@ -1,0 +1,27 @@
+<div class="modal fade" id="confirmResetModal"context="confirmResetModal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>
+        <h4 class="modal-title">Confirm Reset</h4>
+      </div>
+
+      <div class="modal-body">
+        <p>
+          Please enter <mark><%= @tournament.handle %></mark> below to confirm that you
+          want to reset all the data for this tournament.
+        </p>
+
+        <input type="text" bind="input" class="form-control">
+      </div>
+
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        <%= link_to 'Reset', admin_reset_path,
+          method: :post,
+          class: 'btn btn-danger',
+          "bind-class" => "{disabled: input != '#{@tournament.handle}'}" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -7,20 +7,44 @@
   <%= ui_save_button_tag(form_id:'.edit_tournament') %>
 <% end %>
 
+<%= render 'confirm_reset_modal' %>
 <%= render 'admin/errors', object: @tournament %>
 
-<%= ui_box do %>
-  <%= form_for @tournament, url: admin_settings_path, method: :put, remote: true do |form| %>
+<div class="row">
+  <div class="col-md-8">
+    <%= ui_box do %>
+      <%= form_for @tournament, url: admin_settings_path, method: :put, remote: true do |form| %>
 
-    <%= form.ui_text_field :name %>
+        <%= form.ui_text_field :name %>
 
-    <%= form.ui_text_field :handle,
-        help_text: 'This dicates the first part of your website address' %>
+        <%= form.ui_text_field :handle,
+            help_text: 'This dicates the first part of your website address' %>
 
-    <%= form.ui_number_field :time_cap, min: 0,
-        help_text: "This is used to make sure games don't overlap and to help when building your schedule." %>
+        <%= form.ui_number_field :time_cap, min: 0,
+            help_text: "This is used to make sure games don't overlap and to help when building your schedule." %>
 
-    <hr>
-    <%= form.ui_save_button %>
-  <% end %>
-<% end %>
+        <hr>
+        <%= form.ui_save_button %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="col-md-4">
+    <%= ui_box do %>
+      <h4>
+        <i class="fa fa-exclamation-triangle"></i>
+        Reset all Data
+      </h4>
+
+      <p>
+        This is permament and can't be undone
+      </p>
+
+      <div class="pull-right">
+        <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#confirmResetModal">
+          Reset data
+        </button>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -30,6 +30,7 @@ namespace :admin do
 
   get '/settings', to: 'settings#show'
   put '/settings', to: 'settings#update'
+  post '/reset', to: 'settings#reset_data'
 
   get '/map', to: 'map#show'
   put '/map', to: 'map#update'

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -24,4 +24,18 @@ class Admin::SettingsControllerTest < ActionController::TestCase
     put :update, params: { tournament: {name: ''} }
     assert_equal 'Error saving Settings.', flash[:error]
   end
+
+  test "reset clears data" do
+    post :reset_data
+    assert_redirected_to admin_settings_path
+    assert_equal 'Data reset.', flash[:notice]
+
+    assert_equal 0, @tournament.reload.fields.count
+    assert_equal 0, @tournament.reload.teams.count
+    assert_equal 0, @tournament.reload.divisions.count
+    assert_equal 0, @tournament.reload.games.count
+    assert_equal 0, @tournament.reload.pool_results.count
+    assert_equal 0, @tournament.reload.places.count
+    assert_equal 0, @tournament.reload.score_reports.count
+  end
 end


### PR DESCRIPTION
Some users asked for this and it makes sense because a very likely flow is to sign up and play around to see if you think it will work for you. If you're serious you picked the handle you actually want off the bat so then what do you do with your play data?

A topic of debate is whether to delete fields or not. I am right now since its easier to message about. Users may not want to delete fields though. Work around now is export the fields to csv before deleting all data.

It makes you type the handle in order to enable the final button:

![image](https://cloud.githubusercontent.com/assets/1965489/15004326/acc46f52-1183-11e6-95c7-2ed8dce5784c.png)
