### PR TITLE
add round robin to 11.1

### DIFF
--- a/db/brackets.yml
+++ b/db/brackets.yml
@@ -397,6 +397,8 @@
 -
   handle: USAU 11.1
   name: One team advances (USAU 11.1)
+  description: >
+    Bottom 3 teams play a round robin on the second day.
   num_teams: 11
   days: 2
   rounds: 3

--- a/db/brackets/usau_11.1.json
+++ b/db/brackets/usau_11.1.json
@@ -2,7 +2,11 @@
   "games": [
     <%= bracket_partial('table_5.1.1', pool: 'A', seeds: [1,3,6,8,9]) %>
     <%= bracket_partial('table_6.1.2', pool: 'B', seeds: [2,4,5,7,10,11]) %>
-    <%= bracket_partial('bracket_8.1') %>
+    <%= bracket_partial('bracket_8.1') %>,
+
+    {"round": 1, "uid": "aa", "home":"A5", "away":"B6"},
+    {"round": 2, "uid": "bb", "home":"B5", "away":"B6"},
+    {"round": 3, "uid": "cc", "home":"A5", "away":"B5"}
   ],
   "places": [
     {"position":1, "prereq_uid": "Wg"},


### PR DESCRIPTION
updates the 11.1 bracket to have a round robin of 3 for the bottom 3 teams. Not that these don't show up in the render images so add a note to the description.

I added these games manually in heroku console for Nick Lindeke so he didn't lose any scheduling with the update.
