### PR TITLE
include scheduled for the bracket update check

### DIFF
--- a/app/controllers/admin/divisions_controller.rb
+++ b/app/controllers/admin/divisions_controller.rb
@@ -64,7 +64,6 @@ class Admin::DivisionsController < AdminController
 
   def check_update_safety
     @division.assign_attributes(division_params)
-    return if @division.update_safe?
 
     # this is correct since as long as we don't render we continue
     # with the controller action

--- a/app/jobs/divisions/safe_to_update_bracket_job.rb
+++ b/app/jobs/divisions/safe_to_update_bracket_job.rb
@@ -1,0 +1,36 @@
+module Divisions
+  class SafeToUpdateBracketJob < ApplicationJob
+    queue_as :default
+
+    attr_reader :division, :games
+
+    GAMES_SCHEDULE_MESSAGE = 'This division has games that have been scheduled. Changing the bracket' \
+                             ' will reset those games. Are you sure this is what you want to do?'
+
+    GAMES_PLAYED_MESSAGE = 'This division has games that have been scored. Changing the bracket' \
+                           ' will reset those games. Are you sure this is what you want to do?'
+
+    def perform(division:)
+      @division = division
+      @games = division.games
+
+      if games_scheduled?
+        return false, GAMES_SCHEDULE_MESSAGE
+      elsif games_played?
+        return false, GAMES_PLAYED_MESSAGE
+      else
+        return true
+      end
+    end
+
+    private
+
+    def games_played?
+      games.where(score_confirmed: true).exists?
+    end
+
+    def games_scheduled?
+      games.where.not(field_id: nil).exists?
+    end
+  end
+end

--- a/app/views/admin/divisions/_confirm_update.html.erb
+++ b/app/views/admin/divisions/_confirm_update.html.erb
@@ -7,8 +7,7 @@
 
     <div class="modal-body">
       <p>
-        This division has games that have been scored. Changing the bracket
-        will reset those games. Are you sure this is what you want to do?
+        <%= @division.change_message %>
       </p>
     </div>
 

--- a/test/controllers/admin/divisions_controller_test.rb
+++ b/test/controllers/admin/divisions_controller_test.rb
@@ -60,8 +60,6 @@ class Admin::DivisionsControllerTest < ActionController::TestCase
   end
 
   test "update a division (unsafe)" do
-    refute @division.safe_to_change?
-
     params = division_params.merge(bracket_type: 'single_elimination_4')
     put :update, params: { id: @division.id, division: params }
 
@@ -70,8 +68,6 @@ class Admin::DivisionsControllerTest < ActionController::TestCase
   end
 
   test "update a division (unsafe) + confirm" do
-    refute @division.safe_to_change?
-
     params = division_params.merge(bracket_type: 'single_elimination_4')
     put :update, params: { id: @division.id, division: params, confirm: 'true' }
 

--- a/test/jobs/divisions/safe_to_update_bracket_job_test.rb
+++ b/test/jobs/divisions/safe_to_update_bracket_job_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+module Divisions
+  class SafeToUpdateBracketJobTest < ActiveJob::TestCase
+    setup do
+      @tournament = tournaments(:noborders)
+      @division = divisions(:women)
+      @game = games(:semi_final)
+    end
+
+    test "update is safe if no games are scheduled or played" do
+      @game.update_columns(field_id: nil)
+      safe, message = perform
+      assert safe
+    end
+
+    test "unsafe if games are scheduled" do
+      assert @game.field_id
+      safe, message = perform
+      refute safe
+      assert_match 'have been scheduled', message
+    end
+
+    test "unsafe if games are played" do
+      @game.update_columns(field_id: nil, score_confirmed: true)
+      safe, message = perform
+      refute safe
+      assert_match 'have been scored', message
+    end
+
+    def perform
+      SafeToUpdateBracketJob.perform_now(division: @division)
+    end
+  end
+end


### PR DESCRIPTION
Includes scheduled games in the safety check since otherwise a TD might change a bracket and be upset when all the games are un-scheduled.

Future Work:
Is it worth doing a smarter recreate that doesn't affect unchanged games to avoid some rescheduling (and possibly re-scoring although this could be quiet complex) 
