### PR TITLE
[WIP] Add Peek

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,11 @@ gem 'wicked_pdf'
 gem 'browser-timezone-rails'
 gem 'config'
 
+gem 'peek'
+gem 'peek-git'
+gem 'peek-host'
+gem 'peek-performance_bar'
+
 # model gems
 gem 'frozen_record', '~> 0.7.1'
 gem 'paranoia', git: 'https://github.com/rubysherpas/paranoia', ref: '3c0d897a3e0eb49c7ff8ee7ad9ba221d41ff160a'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    concurrent-ruby-ext (1.0.2)
+      concurrent-ruby (~> 1.0.2)
     config (1.2.0)
       activesupport (>= 3.0)
       deep_merge (~> 1.0, >= 1.0.1)
@@ -203,6 +205,17 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
+    peek (0.2.0)
+      coffee-rails
+      concurrent-ruby (>= 0.9.0)
+      concurrent-ruby-ext (>= 0.9.0)
+      railties (>= 3.0.0)
+    peek-git (1.0.2)
+      peek
+    peek-host (1.0.0)
+      peek
+    peek-performance_bar (1.2.1)
+      peek (>= 0.1.0)
     pg (0.18.4)
     phonelib (0.6.0)
     pkg-config (1.1.7)
@@ -373,6 +386,10 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-google-oauth2
   paranoia!
+  peek
+  peek-git
+  peek-host
+  peek-performance_bar
   pg
   phonelib
   poltergeist

--- a/app/assets/javascripts/admin_vendor.js
+++ b/app/assets/javascripts/admin_vendor.js
@@ -4,6 +4,9 @@
 //= require turbolinks
 //= require bootstrap-sprockets
 
+//= require peek
+//= require peek/views/performance_bar
+
 //= require jquery.cookie
 //= require jstz
 //= require browser_timezone_rails/set_time_zone

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -12,4 +12,7 @@
 @import 'leaflet';
 @import 'vis';
 
+@import 'peek';
+@import 'peek/views/performance_bar';
+
 @import 'admin/*';

--- a/app/assets/stylesheets/admin/peek.scss
+++ b/app/assets/stylesheets/admin/peek.scss
@@ -1,0 +1,11 @@
+#peek {
+  position: fixed;
+  bottom: 0;
+  left: $sidebar-width;
+  right: 0;
+  z-index: 999;
+  background: #222d32 !important;
+  .wrapper {
+    margin-left: 10px;
+  }
+}

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -51,6 +51,7 @@ class AdminController < ApplicationController
     end
   end
 
+  # for action cable
   def set_tournament_cookie
     cookies.signed['tournament.id'] = {
       value: @tournament.id,
@@ -60,6 +61,10 @@ class AdminController < ApplicationController
       value: 30.minutes.from_now,
       domain: :all
     }
+  end
+
+  def peek_enabled?
+    current_user.staff?
   end
 
   def set_admin_cookie

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -24,6 +24,7 @@
   <div class="modal fade" id="confirmActionModal">
   </div>
 
+  <%= render 'peek/bar' %>
   <%= render 'admin/flash' %>
 </body>
 </html>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,4 +86,8 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  Peeked::Application.configure do
+    config.peek.adapter = :memcache
+  end
 end

--- a/config/initializers/peek.rb
+++ b/config/initializers/peek.rb
@@ -1,0 +1,3 @@
+Peek.into Peek::Views::Git
+Peek.into Peek::Views::Host
+Peek.into Peek::Views::PerformanceBar

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,8 @@ Rails.application.routes.draw do
 
   mount ActionCable.server => '/cable'
 
+  mount Peek::Railtie => '/peek'
+
   get '/tos' => 'brochure#tos'
   root 'brochure#index'
 end


### PR DESCRIPTION
I put peek at the bottom since this seemed to work best with AdminLTE (although hovering on the perf bar still makes something appear at the top but its invisible and it moves the rest of the page). Might be a pain to keep at the bottom since other plugins might try and render stuff below it. Fixing AdminLTE was also hard though.

![image](https://cloud.githubusercontent.com/assets/1965489/16348963/b29a0e14-3a23-11e6-9b70-8d5b93672504.png)

Also would be cool to add bullet output to peek. I was quiet surprised there wasn't a gem for this. Might be a good open source opportunity.
