### PR TITLE
fix pool finished job to be idempotent

### DIFF
--- a/app/jobs/divisions/finish_pool_job.rb
+++ b/app/jobs/divisions/finish_pool_job.rb
@@ -2,45 +2,18 @@ module Divisions
   class FinishPoolJob < ApplicationJob
     attr_reader :division, :pool
 
-    def perform(division:, pool:)
-      @division, @pool = division, pool
-      return unless pool_finished?
-      clear_results
-      record_results
+    def perform(division:, pool_uid:)
+      @division = division
+      @pool = Pool.new(division, pool_uid)
+
+      return unless pool.finished?
+      pool.clear_results
+      pool.persist_results
       reseed
       push_places
     end
 
     private
-
-    def pool_finished?
-      Division::pool_finished?(
-        tournament_id: division.tournament_id,
-        division_id: division.id,
-        pool: pool
-      )
-    end
-
-    def record_results
-      sorted_teams.each_with_index do |team, idx|
-        position = idx + 1
-        PoolResult.create!(
-          tournament_id: division.tournament_id,
-          division_id: division.id,
-          pool: pool,
-          position: position,
-          team: team
-        )
-      end
-    end
-
-    def clear_results
-      PoolResult.where(
-        tournament_id: division.tournament_id,
-        division_id: division.id,
-        pool: pool,
-      ).destroy_all
-    end
 
     def reseed
       division.games.each do |game|
@@ -76,53 +49,15 @@ module Divisions
     end
 
     def prereq_uid_from_pool?(prereq_uid)
-      prereq_uid =~ /#{pool}\d/
+      prereq_uid =~ /#{pool.uid}\d/
     end
 
     def team_for_prereq(prereq_uid)
-      sorted_teams[ pool_place_index_from_prereq(prereq_uid) ]
+      pool.results[ pool_place_index_from_prereq(prereq_uid) ]
     end
 
     def pool_place_index_from_prereq(prereq_uid)
-      prereq_uid.gsub(pool, '').to_i - 1
-    end
-
-    def sorted_teams
-      @sorted_teams ||= begin
-
-        team_wins = Hash.new(0)
-        team_pts = Hash.new(0)
-        games_for_pool.each do |game|
-          if game.tie?
-            team_wins[game.home_id] += 1
-            team_wins[game.away_id] += 1
-          else
-            team_wins[game.winner.id] += 1
-          end
-
-          team_pts[game.home_id] += game.home_score
-          team_pts[game.away_id] += game.away_score
-        end
-
-        teams = teams_for_pool.sort_by do |team|
-          [team_wins[team.id], team_pts[team.id]]
-        end.reverse
-
-        teams
-      end
-    end
-
-    def teams_for_pool
-      team_ids = division.games
-        .where(pool: pool)
-        .pluck(:home_id, :away_id)
-        .flatten.uniq
-
-      division.teams.where(id: team_ids)
-    end
-
-    def games_for_pool
-      division.games.where(pool: pool)
+      prereq_uid.gsub(pool.uid, '').to_i - 1
     end
   end
 end

--- a/app/jobs/games/safe_to_update_score_job.rb
+++ b/app/jobs/games/safe_to_update_score_job.rb
@@ -6,32 +6,40 @@ module Games
       @game, @home_score, @away_score = game, home_score, away_score
 
       return true if game.unconfirmed?
-      if game.pool_game?
-        !(pool_finished? && bracket_games_played?)
+
+      unsafe = if game.pool_game?
+        safe_for_pool_game?
       elsif game.bracket_game?
-        !winner_changed? || !dependent_games_played?
+        safe_for_bracket_game?
       end
+
+      !unsafe
     end
 
     private
 
-    def winner_changed?
-      (game.home_score > game.away_score) ^ (home_score > away_score)
+    def safe_for_pool_game?
+      pool = Pool.new(game.division, game.pool)
+
+      pool.finished? &&
+      pool.results_changed?(game, home_score, away_score) &&
+      bracket_games_played?
     end
 
-    def pool_finished?
-      Division::pool_finished?(
-        tournament_id: game.tournament_id,
-        division_id: game.division_id,
-        pool: game.pool
-      )
+    def safe_for_bracket_game?
+      winner_changed? && dependent_games_played?
+    end
+
+    def winner_changed?
+      (game.home_score > game.away_score) ^ (home_score > away_score)
     end
 
     def bracket_games_played?
       games = Game.where(
         tournament_id: game.tournament_id,
         division_id: game.division_id,
-        round: 1
+        round: 1,
+        pool: nil
       )
       games.any?{ |g| g.confirmed? }
     end

--- a/app/jobs/games/update_score_job.rb
+++ b/app/jobs/games/update_score_job.rb
@@ -63,7 +63,7 @@ module Games
     def update_pool
       Divisions::FinishPoolJob.perform_later(
         division: game.division,
-        pool: game.pool
+        pool_uid: game.pool
       )
     end
 

--- a/app/models/division.rb
+++ b/app/models/division.rb
@@ -40,11 +40,6 @@ class Division < ApplicationRecord
     Divisions::SeedJob.perform_now(division: self, seed_round: seed_round)
   end
 
-  def self.pool_finished?(tournament_id:, division_id:, pool:)
-    games = Game.where(tournament_id: tournament_id, division_id: division_id, pool: pool)
-    games.all? { |game| game.confirmed? }
-  end
-
   def safe_to_change?
     return true unless self.bracket_type_changed?
     safe, @change_message = Divisions::SafeToUpdateBracketJob.perform_now(division: self)

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -1,0 +1,92 @@
+class Pool
+  attr_reader :division, :uid
+
+  def initialize(division, uid)
+    @division = division
+    @uid = uid
+  end
+
+  def finished?
+    games.all? { |game| game.confirmed? }
+  end
+
+  def results(updated_game: nil, home_score: nil, away_score: nil)
+    @results ||= begin
+      team_wins = Hash.new(0)
+      team_pts = Hash.new(0)
+
+      games.each do |game|
+        if updated_game == game
+          game.home_score = home_score
+          game.away_score = away_score
+        end
+
+        if game.tie?
+          team_wins[game.home_id] += 1
+          team_wins[game.away_id] += 1
+        else
+          team_wins[game.winner.id] += 1
+        end
+
+        team_pts[game.home_id] += game.home_score
+        team_pts[game.away_id] += game.away_score
+      end
+
+      sorted_teams = teams.sort_by do |team|
+        [team_wins[team.id], team_pts[team.id]]
+      end.reverse
+
+      sorted_teams
+    end
+  end
+
+  def results_changed?(game, home_score, away_score)
+    old_results = persisted_results.order(position: :asc)
+    new_results = results(updated_game: game, home_score: home_score, away_score: away_score)
+
+    new_results.each_with_index do |team, idx|
+      return true if old_results[idx].try(:team) != team
+    end
+    false
+  end
+
+  def persist_results
+    results.each_with_index do |team, idx|
+      position = idx + 1
+      PoolResult.create!(
+        tournament_id: division.tournament_id,
+        division_id: division.id,
+        pool: uid,
+        position: position,
+        team: team
+      )
+    end
+  end
+
+  def clear_results
+    persisted_results.destroy_all
+  end
+
+  private
+
+  def teams
+    team_ids = division.games
+      .where(pool: uid)
+      .pluck(:home_id, :away_id)
+      .flatten.uniq
+
+    division.teams.where(id: team_ids)
+  end
+
+  def games
+    @games ||= division.games.where(pool: uid)
+  end
+
+  def persisted_results
+    PoolResult.where(
+      tournament_id: division.tournament_id,
+      division_id: division.id,
+      pool: uid,
+    )
+  end
+end

--- a/test/jobs/divisions/finish_pool_job_test.rb
+++ b/test/jobs/divisions/finish_pool_job_test.rb
@@ -13,7 +13,7 @@ module Divisions
       @teams.update_all(division_id: division.id)
 
       Game.any_instance.expects(:save!).never
-      FinishPoolJob.perform_now(division: division, pool: 'A')
+      FinishPoolJob.perform_now(division: division, pool_uid: 'A')
     end
 
     test "records pool results" do
@@ -25,7 +25,7 @@ module Divisions
       play_pool(@teams, division, 'A')
 
       assert_difference 'PoolResult.count', +4 do
-        FinishPoolJob.perform_now(division: division, pool: 'A')
+        FinishPoolJob.perform_now(division: division, pool_uid: 'A')
       end
     end
 
@@ -46,7 +46,7 @@ module Divisions
       )
 
       assert_difference 'PoolResult.count', +3 do
-        FinishPoolJob.perform_now(division: division, pool: 'A')
+        FinishPoolJob.perform_now(division: division, pool_uid: 'A')
       end
 
       assert_raises ActiveRecord::RecordNotFound do
@@ -62,7 +62,7 @@ module Divisions
 
       play_pool(@teams, division, 'A')
 
-      FinishPoolJob.perform_now(division: division, pool: 'A')
+      FinishPoolJob.perform_now(division: division, pool_uid: 'A')
 
       game1 = division.games.find_by(home_prereq_uid: 'A1')
       game2 = division.games.find_by(away_prereq_uid: 'A4')
@@ -101,7 +101,7 @@ module Divisions
         score_confirmed: true
       )
 
-      FinishPoolJob.perform_now(division: division, pool: 'A')
+      FinishPoolJob.perform_now(division: division, pool_uid: 'A')
       results = division.pool_results.order(:position)
 
       assert_equal @teams[2], results[0].team
@@ -154,7 +154,7 @@ module Divisions
         score_confirmed: true
       )
 
-      FinishPoolJob.perform_now(division: division, pool: 'A')
+      FinishPoolJob.perform_now(division: division, pool_uid: 'A')
       results = division.pool_results.order(:position)
 
       assert_equal @teams[0], results[0].team
@@ -175,7 +175,7 @@ module Divisions
       game2 = division.games.find_by(away_prereq_uid: 'A4')
 
       perform_enqueued_jobs do
-        FinishPoolJob.perform_now(division: division, pool: 'A')
+        FinishPoolJob.perform_now(division: division, pool_uid: 'A')
         assert_equal teams.first, game1.reload.home
         assert_equal teams.last, game2.reload.away
       end
@@ -194,7 +194,7 @@ module Divisions
       division.reload
 
       perform_enqueued_jobs do
-        FinishPoolJob.perform_now(division: division, pool: 'A')
+        FinishPoolJob.perform_now(division: division, pool_uid: 'A')
         refute game1.reload.confirmed?
         refute game2.reload.confirmed?
       end
@@ -212,7 +212,7 @@ module Divisions
       game2 = division.games.find_by(away_prereq_uid: 'A4')
 
       perform_enqueued_jobs do
-        FinishPoolJob.perform_now(division: division, pool: 'A')
+        FinishPoolJob.perform_now(division: division, pool_uid: 'A')
         assert_equal teams.first, game1.reload.home
         assert_equal teams.last, game2.reload.away
       end
@@ -221,7 +221,7 @@ module Divisions
       game2.update_column(:score_confirmed, true)
 
       perform_enqueued_jobs do
-        FinishPoolJob.perform_now(division: division, pool: 'A')
+        FinishPoolJob.perform_now(division: division, pool_uid: 'A')
         assert game1.reload.confirmed?
         assert game2.reload.confirmed?
       end


### PR DESCRIPTION
Pool Finished job didn't use active record dirty properly and as a result was not idempotent. This resulted in me erasing some data while updating a pool in a way that didn't affect future games.

Now it checks if any teams were actually re-assigned.

Also made some refactors for smaller methods.
