### PR TITLE
browser tests can use transactional fixtures now

### DIFF
--- a/test/browser/app_browser_test.rb
+++ b/test/browser/app_browser_test.rb
@@ -85,7 +85,5 @@ class AppBrowserTest < BrowserTest
   #   assert_equal 15, report.team_score
   #   assert_equal 11, report.opponent_score
   #   assert report.submitter_fingerprint
-  #
-  #   report.destroy!
   # end
 end

--- a/test/browser/signup_browser_test.rb
+++ b/test/browser/signup_browser_test.rb
@@ -26,7 +26,5 @@ class SignupBrowserTest < BrowserTest
     assert_equal 'New Tournament', tournament.name
     assert_equal 80, tournament.time_cap
     assert_equal 'Ottawa', tournament.location
-
-    assert tournament.destroy()
   end
 end

--- a/test/support/browser_test.rb
+++ b/test/support/browser_test.rb
@@ -14,7 +14,6 @@ end
 
 class BrowserTest < ActiveSupport::TestCase
   include Capybara::DSL
-  self.use_transactional_tests = false
 
   setup do
     @user = users(:kevin)


### PR DESCRIPTION
while setting up a new project I discovered that browser tests can now use transactional fixtures and access objects created during the request. This must be thanks to Rails 5 (I should look into this!)
