### PR TITLE
always notify if a score report submit fails

### DIFF
--- a/app/operations/score_report_create.rb
+++ b/app/operations/score_report_create.rb
@@ -12,7 +12,11 @@ class ScoreReportCreate < ApplicationOperation
 
     unless report.save
       @errors = report.errors.full_messages
-      halt 'Save failed'
+
+      e = Exception.new(@errors.to_json)
+      Rollbar.error(e)
+
+      fail @errors
     end
 
     notify_other_team

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -9,6 +9,8 @@ Rollbar.configure do |config|
     config.enabled = false
   end
 
+  config.populate_empty_backtraces = true
+
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`,
   # `username`, and `email` methods to fetch those properties. To customize:

--- a/test/operations/score_report_create_test.rb
+++ b/test/operations/score_report_create_test.rb
@@ -31,6 +31,21 @@ class ScoreReportCreateTest < ActiveSupport::TestCase
     create.perform
   end
 
+  test "if saving fails notify of the error" do
+    params = score_report_params
+    params[:opponent_score] = -1
+
+    Rollbar.expects(:error).once
+
+    create = ScoreReportCreate.new(
+      params,
+      @tournament.game_confirm_setting
+    )
+    create.perform
+
+    assert create.failed?
+  end
+
   private
 
   def score_report_params


### PR DESCRIPTION
This is a critical path for my app and one that I need to be very aware of failures along. It works out nicely that all I need is to send some manual Rollbar right from the operation.
