### PR TITLE
fix score report confirm bug

### DIFF
--- a/app/views/score_reports/token_not_found.html
+++ b/app/views/score_reports/token_not_found.html
@@ -1,5 +1,5 @@
 <div class="bar bar-nav bar-blue">
-  <h1 class="title">Token not found</h1>
+  <h1 class="title">Link expired</h1>
 </div>
 
 <div class="content-padded">

--- a/config/routes/player_app.rb
+++ b/config/routes/player_app.rb
@@ -1,4 +1,4 @@
 get '/' => 'app#show', as: 'app'
 post '/submit_score' => 'score_reports#submit', as: 'app_score_submit'
-get '/confirm/:id' => 'score_reports#confirm_post', as: 'app_confirm'
-post '/confirm/:id' => 'score_reports#confirm_get'
+get '/confirm/:id' => 'score_reports#confirm_get', as: 'app_confirm'
+post '/confirm/:id' => 'score_reports#confirm_post'


### PR DESCRIPTION
closes #685 

The code was all correct but there was a route typo. Controller tests don't use routes though so it was not caught. As a regression test I updated the tests to `ActionDispatch::IntegrationTest` since controller tests are deprecated in Rails 5 anyways.

I also changed the copy on the 404 token page to say `Link expired` since I think that makes more sense to end users.